### PR TITLE
Utils — Minimax (#2)

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,3 +3,4 @@
 
 # ** app
 from .board_utils import BoardUtils as Board
+from .minimax import Minimax

--- a/app/utils/minimax.py
+++ b/app/utils/minimax.py
@@ -1,0 +1,78 @@
+# *** imports
+
+# ** core
+from typing import List, Tuple
+
+# ** app
+from .board_utils import BoardUtils
+
+
+# *** utils
+
+# ** util: minimax
+class Minimax:
+    '''
+    Stateless computational utility implementing plain recursive minimax for tic-tac-toe.
+    '''
+
+    # * method: search (static)
+    @staticmethod
+    def search(board: List[int], is_maximizing: bool) -> Tuple[int, int]:
+        '''
+        Plain recursive minimax search.
+
+        :param board: The current board state.
+        :type board: List[int]
+        :param is_maximizing: True if the current player is maximizing (X).
+        :type is_maximizing: bool
+        :return: A tuple of (utility value, total nodes evaluated).
+        :rtype: Tuple[int, int]
+        '''
+
+        # Base case: return utility if terminal state.
+        if BoardUtils.is_terminal(board):
+            return BoardUtils.utility(board), 1
+
+        # Determine the current player from maximizing flag.
+        player = 1 if is_maximizing else -1
+
+        # Initialize best value and node counter.
+        node_count = 1
+        if is_maximizing:
+            best = float('-inf')
+        else:
+            best = float('inf')
+
+        # Evaluate each successor.
+        for _, child in BoardUtils.get_successors(board, player):
+
+            # Recurse into the child state.
+            value, child_nodes = Minimax.search(child, not is_maximizing)
+            node_count += child_nodes
+
+            # Update best value.
+            if is_maximizing:
+                best = max(best, value)
+            else:
+                best = min(best, value)
+
+        # Return the best value and total nodes evaluated.
+        return best, node_count
+
+    # * method: run (static)
+    @staticmethod
+    def run(board: List[int]) -> Tuple[int, int]:
+        '''
+        Run minimax from the given board state, auto-detecting whose turn it is.
+
+        :param board: The current board state.
+        :type board: List[int]
+        :return: A tuple of (utility value, total nodes evaluated).
+        :rtype: Tuple[int, int]
+        '''
+
+        # Determine if the current player is maximizing.
+        is_maximizing = BoardUtils.current_player(board) == 1
+
+        # Run minimax and return the result.
+        return Minimax.search(board, is_maximizing)

--- a/docs/guides/utils/minimax.md
+++ b/docs/guides/utils/minimax.md
@@ -1,0 +1,37 @@
+# Minimax
+
+**Module:** `app/utils/minimax.py`
+
+Plain recursive minimax search. All methods are static — no pruning, no callbacks, no side effects.
+
+## Methods
+
+### `search(board: List[int], is_maximizing: bool) -> Tuple[int, int]`
+
+Runs a full minimax search from the given board state. Every node in the game tree is explored — no pruning.
+
+- **`board`** — Current board state as `List[int]`.
+- **`is_maximizing`** — `True` if the current player is X (maximizer), `False` for O (minimizer).
+- **Returns** — `(utility_value, node_count)` where `node_count` includes every recursive call (internal nodes + terminals).
+
+```python
+from app.utils.board_utils import BoardUtils
+from app.utils.minimax import Minimax
+
+board = BoardUtils.parse_board('O_XOXX___')
+value, nodes = Minimax.search(board, is_maximizing=False)
+# value = -1 (O wins), nodes = 26
+```
+
+### `run(board: List[int]) -> Tuple[int, int]`
+
+Convenience wrapper that auto-detects whose turn it is via `BoardUtils.current_player()` and calls `search()`.
+
+```python
+value, nodes = Minimax.run(BoardUtils.parse_board('O_XOXX___'))
+# value = -1, nodes = 26
+```
+
+## Node Counting
+
+Every call to `search()` counts as one node — both internal (non-terminal) nodes and leaf (terminal) nodes. The total is the sum across the entire recursion tree. This matches the "moves considered" metric in the output.


### PR DESCRIPTION
## Summary

Add the `Minimax` utility class with static methods for plain recursive minimax search. This serves as the baseline algorithm against which Alpha-Beta pruning will be compared.

## Changes

- **`app/utils/minimax.py`** — `Minimax` class with `search()` and `run()` static methods.
- **`app/utils/__init__.py`** — Added `Minimax` export.
- **`docs/guides/utils/minimax.md`** — Usage guide with examples and node counting explanation.

## Acceptance Criteria Verified

- `Minimax.run(BoardUtils.parse_board('O_XOXX___'))` → `(-1, 26)` ✓
- `Minimax.run(BoardUtils.parse_board('XOXOXOXOX'))` → `(1, 1)` (terminal) ✓
- Terminal boards return immediately with node count 1 ✓
- Export alias from `app.utils` works ✓

Closes #2

Co-Authored-By: Oz <oz-agent@warp.dev>