### PR TITLE
Utils — AlphaBeta

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -4,3 +4,4 @@
 # ** app
 from .board_utils import BoardUtils as Board
 from .minimax import Minimax
+from .alphabeta import AlphaBeta

--- a/app/utils/alphabeta.py
+++ b/app/utils/alphabeta.py
@@ -1,0 +1,118 @@
+# *** imports
+
+# ** core
+from typing import List, Tuple, Callable, Optional
+
+# ** app
+from .board_utils import BoardUtils
+
+
+# *** utils
+
+# ** util: alphabeta
+class AlphaBeta:
+    '''
+    Stateless computational utility implementing alpha-beta pruning for tic-tac-toe.
+    '''
+
+    # * method: search (static)
+    @staticmethod
+    def search(board: List[int],
+            alpha: float,
+            beta: float,
+            is_maximizing: bool,
+            on_cutoff: Optional[Callable] = None) -> Tuple[int, int]:
+        '''
+        Alpha-beta pruning search.
+
+        When a cutoff occurs, calls on_cutoff(board, cutoff_type) if provided,
+        where board is the parent board state at the current recursive call.
+
+        :param board: The current board state.
+        :type board: List[int]
+        :param alpha: The alpha bound.
+        :type alpha: float
+        :param beta: The beta bound.
+        :type beta: float
+        :param is_maximizing: True if the current player is maximizing (X).
+        :type is_maximizing: bool
+        :param on_cutoff: Optional callback invoked on pruning events.
+        :type on_cutoff: Optional[Callable]
+        :return: A tuple of (utility value, total nodes evaluated).
+        :rtype: Tuple[int, int]
+        '''
+
+        # Base case: return utility if terminal state.
+        if BoardUtils.is_terminal(board):
+            return BoardUtils.utility(board), 1
+
+        # Determine the current player from maximizing flag.
+        player = 1 if is_maximizing else -1
+
+        # Initialize node counter.
+        node_count = 1
+
+        # Maximizing player logic.
+        if is_maximizing:
+            best = float('-inf')
+
+            for _, child in BoardUtils.get_successors(board, player):
+
+                # Recurse into the child state.
+                value, child_nodes = AlphaBeta.search(child, alpha, beta, False, on_cutoff)
+                node_count += child_nodes
+
+                # Update best value and alpha.
+                best = max(best, value)
+                alpha = max(alpha, best)
+
+                # Beta cutoff: prune remaining branches.
+                if alpha >= beta:
+                    if on_cutoff:
+                        on_cutoff(board, 'Beta cut')
+                    break
+
+            return best, node_count
+
+        # Minimizing player logic.
+        else:
+            best = float('inf')
+
+            for _, child in BoardUtils.get_successors(board, player):
+
+                # Recurse into the child state.
+                value, child_nodes = AlphaBeta.search(child, alpha, beta, True, on_cutoff)
+                node_count += child_nodes
+
+                # Update best value and beta.
+                best = min(best, value)
+                beta = min(beta, best)
+
+                # Alpha cutoff: prune remaining branches.
+                if beta <= alpha:
+                    if on_cutoff:
+                        on_cutoff(board, 'Alpha cut')
+                    break
+
+            return best, node_count
+
+    # * method: run (static)
+    @staticmethod
+    def run(board: List[int],
+            on_cutoff: Optional[Callable] = None) -> Tuple[int, int]:
+        '''
+        Run alpha-beta search from the given board state, auto-detecting whose turn it is.
+
+        :param board: The current board state.
+        :type board: List[int]
+        :param on_cutoff: Optional callback invoked on pruning events.
+        :type on_cutoff: Optional[Callable]
+        :return: A tuple of (utility value, total nodes evaluated).
+        :rtype: Tuple[int, int]
+        '''
+
+        # Determine if the current player is maximizing.
+        is_maximizing = BoardUtils.current_player(board) == 1
+
+        # Run alpha-beta with initial bounds.
+        return AlphaBeta.search(board, float('-inf'), float('inf'), is_maximizing, on_cutoff)

--- a/docs/guides/utils/alphabeta.md
+++ b/docs/guides/utils/alphabeta.md
@@ -1,0 +1,58 @@
+# AlphaBeta
+
+**Module:** `app/utils/alphabeta.py`
+
+Alpha-beta pruning search. All methods are static — pure computation with no side effects. Cutoff events are reported via an optional callback rather than printing directly.
+
+## Methods
+
+### `search(board, alpha, beta, is_maximizing, on_cutoff=None) -> Tuple[int, int]`
+
+Runs alpha-beta pruning search from the given board state.
+
+- **`board`** — Current board state as `List[int]`.
+- **`alpha`** / **`beta`** — Current bounds as `float`.
+- **`is_maximizing`** — `True` if the current player is X (maximizer).
+- **`on_cutoff`** — Optional callable invoked as `on_cutoff(board, cutoff_type)` when pruning occurs. `board` is the parent board state at the point of cutoff. `cutoff_type` is `'Alpha cut'` or `'Beta cut'`.
+- **Returns** — `(utility_value, node_count)`.
+
+**Cutoff semantics:**
+- **Beta cutoff** (maximizing node): `alpha >= beta` — the maximizer found a value that exceeds the minimizer's best option, so remaining branches are pruned.
+- **Alpha cutoff** (minimizing node): `beta <= alpha` — the minimizer found a value below the maximizer's best option.
+
+```python
+from app.utils.board_utils import BoardUtils
+from app.utils.alphabeta import AlphaBeta
+
+board = BoardUtils.parse_board('O_XOXX___')
+cutoffs = []
+value, nodes = AlphaBeta.search(
+    board, float('-inf'), float('inf'), False,
+    on_cutoff=lambda b, t: cutoffs.append((b, t))
+)
+# value = -1, nodes = 17, cutoffs has 5 entries
+```
+
+### `run(board: List[int], on_cutoff=None) -> Tuple[int, int]`
+
+Convenience wrapper that auto-detects whose turn it is and initializes alpha/beta to `±inf`.
+
+```python
+value, nodes = AlphaBeta.run(
+    BoardUtils.parse_board('O_XOXX___'),
+    on_cutoff=lambda b, t: print(f'{t} at {b}')
+)
+```
+
+## The `on_cutoff` Callback
+
+The callback is the key design feature that keeps this utility side-effect-free. In the full application, `GameResultAggregate.record_cutoff` is passed as the callback — the aggregate creates `Cutoff` domain objects and collects them for later formatting by the `PrintResults` event.
+
+The callback signature is:
+
+```python
+def on_cutoff(board: List[int], cutoff_type: str) -> None
+```
+
+- **`board`** — The board state at the node where pruning occurred (the parent, not the child that triggered it).
+- **`cutoff_type`** — Either `'Alpha cut'` or `'Beta cut'`.


### PR DESCRIPTION
## Summary

Add the `AlphaBeta` utility class with static `search()` and `run()` methods implementing alpha-beta pruning search for tic-tac-toe.

### Key Design
- **Callback-based cutoff reporting** via optional `on_cutoff` parameter — no printing or I/O in the utility.
- `on_cutoff(board, cutoff_type)` receives the parent board state and `'Alpha cut'` / `'Beta cut'` string.
- Package export added in `app/utils/__init__.py`.

### Files
- `app/utils/alphabeta.py` — `AlphaBeta` class
- `app/utils/__init__.py` — updated exports
- `docs/guides/utils/alphabeta.md` — usage guide

### Acceptance Criteria Verified
1. `AlphaBeta.run('O_XOXX___')` → `(-1, 17)` ✓
2. 5 cutoffs collected via callback ✓
3. Terminal board → `(1, 1)`, 0 callbacks ✓
4. `on_cutoff=None` produces no side effects ✓
5. Cutoff types correct ✓

Closes #3

Co-Authored-By: Oz <oz-agent@warp.dev>