### PR TITLE
Domain — TicTacToeBoard

### DIFF
--- a/app/domain/__init__.py
+++ b/app/domain/__init__.py
@@ -1,0 +1,4 @@
+# *** exports
+
+# ** app
+from .board import TicTacToeBoard

--- a/app/domain/board.py
+++ b/app/domain/board.py
@@ -1,0 +1,19 @@
+# *** imports
+
+# ** infra
+from tiferet import DomainObject, ListType, IntegerType
+
+
+# *** models
+
+# ** model: tic_tac_toe_board
+class TicTacToeBoard(DomainObject):
+    '''
+    Read-only domain object representing a tic-tac-toe board state.
+    '''
+
+    # * attribute: cells
+    cells = ListType(IntegerType, required=True)
+
+    # * attribute: current_player
+    current_player = IntegerType(required=True)

--- a/docs/guides/domain/board.md
+++ b/docs/guides/domain/board.md
@@ -1,0 +1,31 @@
+# TicTacToeBoard
+
+**Module:** `app/domain/board.py`
+
+A read-only domain object representing a tic-tac-toe board state.
+
+## Attributes
+
+- **`cells`** — `ListType(IntegerType)`, required. The board as a list of 9 integers (`1` = X, `-1` = O, `0` = empty).
+- **`current_player`** — `IntegerType`, required. The player whose turn it is (`1` for X, `-1` for O).
+
+## Usage
+
+```python
+from tiferet import DomainObject
+from app.domain.board import TicTacToeBoard
+
+board = DomainObject.new(
+    TicTacToeBoard,
+    cells=[-1, 0, 1, -1, 1, 1, 0, 0, 0],
+    current_player=-1,
+)
+
+print(board.cells)           # [-1, 0, 1, -1, 1, 1, 0, 0, 0]
+print(board.current_player)  # -1
+```
+
+## Notes
+
+- This domain object is not currently used in the runtime flow — the solve event works directly with `List[int]` from `BoardUtils.parse_board()`. It exists as a structural definition for the board concept and can be used in future extensions (e.g., persisting game state, passing typed objects between events).
+- As a `DomainObject`, it is read-only. If mutation is needed, define an aggregate in `app/mappers/`.


### PR DESCRIPTION
## Summary

Add the `TicTacToeBoard` read-only domain object representing a tic-tac-toe board state.

### Files
- `app/domain/board.py` — `TicTacToeBoard(DomainObject)` with `cells` and `current_player` attributes
- `app/domain/__init__.py` — package exports
- `docs/guides/domain/board.md` — usage guide

### Acceptance Criteria Verified
1. Valid instantiation via `DomainObject.new()` ✓
2. Missing `cells` raises `DataError` ✓
3. Missing `current_player` raises `DataError` ✓
4. Package-level export works ✓
5. Artifact comments and RST docstrings ✓
6. Guide exists ✓

Closes #4

Co-Authored-By: Oz <oz-agent@warp.dev>