### PR TITLE
Domain — Cutoff, GameResult & GameResultAggregate

### DIFF
--- a/app/domain/__init__.py
+++ b/app/domain/__init__.py
@@ -2,3 +2,4 @@
 
 # ** app
 from .board import TicTacToeBoard
+from .result import Cutoff, GameResult

--- a/app/domain/result.py
+++ b/app/domain/result.py
@@ -1,0 +1,44 @@
+# *** imports
+
+# ** infra
+from tiferet import (
+    DomainObject,
+    IntegerType,
+    StringType,
+    ListType,
+    ModelType,
+)
+
+
+# *** models
+
+# ** model: cutoff
+class Cutoff(DomainObject):
+    '''
+    Read-only domain object representing a single alpha-beta cutoff event.
+    '''
+
+    # * attribute: board
+    board = ListType(IntegerType, required=True)
+
+    # * attribute: cutoff_type
+    cutoff_type = StringType(required=True)
+
+
+# ** model: game_result
+class GameResult(DomainObject):
+    '''
+    Read-only domain object representing the outcome of a minimax or alpha-beta search.
+    '''
+
+    # * attribute: value
+    value = IntegerType(required=True)
+
+    # * attribute: nodes
+    nodes = IntegerType(required=True)
+
+    # * attribute: algorithm
+    algorithm = StringType(required=True)
+
+    # * attribute: cutoffs
+    cutoffs = ListType(ModelType(Cutoff), default=[])

--- a/app/mappers/__init__.py
+++ b/app/mappers/__init__.py
@@ -1,0 +1,4 @@
+# *** exports
+
+# ** app
+from .result import GameResultAggregate

--- a/app/mappers/result.py
+++ b/app/mappers/result.py
@@ -1,0 +1,67 @@
+# *** imports
+
+# ** core
+from typing import List
+
+# ** infra
+from tiferet import DomainObject, Aggregate
+
+# ** app
+from ..domain.result import Cutoff, GameResult
+
+
+# *** mappers
+
+# ** mapper: game_result_aggregate
+class GameResultAggregate(GameResult, Aggregate):
+    '''
+    Mutable aggregate for game search results that can record cutoff events.
+    '''
+
+    # * method: record_cutoff
+    def record_cutoff(self, board: List[int], cutoff_type: str) -> None:
+        '''
+        Record a pruning event. This method is passed as the on_cutoff
+        callable into the alpha-beta utility.
+
+        :param board: The board state where the cutoff occurred.
+        :type board: List[int]
+        :param cutoff_type: The type of cutoff ('Alpha cut' or 'Beta cut').
+        :type cutoff_type: str
+        '''
+
+        # Create a new Cutoff domain object.
+        cutoff = DomainObject.new(
+            Cutoff,
+            board=board,
+            cutoff_type=cutoff_type,
+        )
+
+        # Append to the cutoffs list.
+        self.cutoffs.append(cutoff)
+
+    # * property: alpha_cuts
+    @property
+    def alpha_cuts(self) -> int:
+        '''
+        Count the number of alpha cutoffs.
+
+        :return: The number of alpha cutoffs.
+        :rtype: int
+        '''
+
+        # Count cutoffs with type 'Alpha cut'.
+        return sum(1 for c in self.cutoffs if c.cutoff_type == 'Alpha cut')
+
+    # * property: beta_cuts
+    @property
+    def beta_cuts(self) -> int:
+        '''
+        Count the number of beta cutoffs.
+
+        :return: The number of beta cutoffs.
+        :rtype: int
+        '''
+
+        # Count cutoffs with type 'Beta cut'.
+        return sum(1 for c in self.cutoffs if c.cutoff_type == 'Beta cut')

--- a/docs/guides/domain/result.md
+++ b/docs/guides/domain/result.md
@@ -1,0 +1,102 @@
+# Cutoff & GameResult
+
+**Module:** `app/domain/result.py`
+
+Two domain objects sharing the same module — both are part of the result bounded context.
+
+## Cutoff
+
+A read-only domain object representing a single alpha-beta pruning event.
+
+### Attributes
+
+- **`board`** — `ListType(IntegerType)`, required. The board state at the node where pruning occurred.
+- **`cutoff_type`** — `StringType`, required. Either `'Alpha cut'` or `'Beta cut'`.
+
+### Usage
+
+```python
+from tiferet import DomainObject
+from app.domain.result import Cutoff
+
+cutoff = DomainObject.new(
+    Cutoff,
+    board=[-1, -1, 1, -1, 1, 1, 0, 1, 0],
+    cutoff_type='Alpha cut',
+)
+```
+
+Cutoffs are not created directly in application code. Instead, `GameResultAggregate.record_cutoff()` creates them during alpha-beta search.
+
+## GameResult
+
+A read-only domain object representing the result of a game search algorithm.
+
+### Attributes
+
+- **`value`** — `IntegerType`, required. The utility value (`1` = X wins, `-1` = O wins, `0` = draw).
+- **`nodes`** — `IntegerType`, required. Total nodes evaluated during search.
+- **`algorithm`** — `StringType`, required. Either `'minimax'` or `'alphabeta'`.
+- **`cutoffs`** — `ListType(ModelType(Cutoff))`, default `[]`. List of pruning events (empty for minimax results).
+
+### Usage
+
+```python
+from tiferet import DomainObject
+from app.domain.result import GameResult
+
+result = DomainObject.new(
+    GameResult,
+    value=-1,
+    nodes=26,
+    algorithm='minimax',
+)
+
+print(result.value)     # -1
+print(result.cutoffs)   # []
+```
+
+## GameResultAggregate
+
+**Module:** `app/mappers/result.py`
+
+Mutable aggregate extending `GameResult` with cutoff collection.
+
+### Methods
+
+- **`record_cutoff(board: List[int], cutoff_type: str)`** — Creates a `Cutoff` via `DomainObject.new()` and appends it to `self.cutoffs`. This method is passed as the `on_cutoff` callback into `AlphaBeta.run()`.
+
+### Properties
+
+- **`alpha_cuts`** — Count of cutoffs where `cutoff_type == 'Alpha cut'`.
+- **`beta_cuts`** — Count of cutoffs where `cutoff_type == 'Beta cut'`.
+
+### Usage
+
+```python
+from tiferet import Aggregate
+from app.mappers.result import GameResultAggregate
+
+aggregate = Aggregate.new(
+    GameResultAggregate,
+    value=0,
+    nodes=0,
+    algorithm='alphabeta',
+    cutoffs=[],
+    validate=False,
+)
+
+# Pass record_cutoff as the on_cutoff callback to AlphaBeta
+from app.utils.alphabeta import AlphaBeta
+from app.utils.board_utils import BoardUtils
+
+board = BoardUtils.parse_board('O_XOXX___')
+value, nodes = AlphaBeta.run(board, on_cutoff=aggregate.record_cutoff)
+
+aggregate.set_attribute('value', value)
+aggregate.set_attribute('nodes', nodes)
+
+print(aggregate.alpha_cuts)  # 1
+print(aggregate.beta_cuts)   # 4
+print(len(aggregate.cutoffs))  # 5
+```


### PR DESCRIPTION
## Summary

Add the result bounded context: `Cutoff` and `GameResult` as read-only domain objects in `app/domain/result.py`, and `GameResultAggregate` as the mutable aggregate in `app/mappers/result.py`.

### Key Design
- **`Cutoff`** captures individual pruning events (board state + cut type).
- **`GameResult`** holds search outcome with a list of cutoffs.
- **`GameResultAggregate`** extends `GameResult` with `record_cutoff()` — the callable passed into `AlphaBeta.run()`. Derived properties `alpha_cuts` and `beta_cuts` count by type.
- Both domain objects share `result.py` — same bounded context.

### Files
- `app/domain/result.py` — `Cutoff` + `GameResult`
- `app/domain/__init__.py` — updated exports
- `app/mappers/result.py` — `GameResultAggregate`
- `app/mappers/__init__.py` — new package with export
- `docs/guides/domain/result.md` — usage guide

### Acceptance Criteria Verified
1. `DomainObject.new(Cutoff, ...)` ✓
2. `Aggregate.new(GameResultAggregate, ...)` ✓
3. `record_cutoff()` appends Cutoff objects ✓
4. `alpha_cuts` / `beta_cuts` return correct counts ✓
5. Package exports work ✓
6. Guide exists ✓

Closes #5

Co-Authored-By: Oz <oz-agent@warp.dev>