### PR TITLE
Events — SolveTicTacToe & PrintResults

### DIFF
--- a/app/events/__init__.py
+++ b/app/events/__init__.py
@@ -1,0 +1,4 @@
+# *** exports
+
+# ** app
+from .tictactoe import SolveTicTacToe, PrintResults

--- a/app/events/tictactoe.py
+++ b/app/events/tictactoe.py
@@ -1,0 +1,141 @@
+# *** imports
+
+# ** core
+from typing import Any, Dict, List
+
+# ** infra
+from tiferet import DomainEvent, Aggregate
+
+# ** app
+from ..utils.board_utils import BoardUtils
+from ..utils.minimax import Minimax
+from ..utils.alphabeta import AlphaBeta
+from ..mappers.result import GameResultAggregate
+
+
+# *** events
+
+# ** event: solve_tic_tac_toe
+class SolveTicTacToe(DomainEvent):
+    '''
+    Domain event that runs both minimax and alpha-beta searches.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['board'])
+    def execute(self, board: str, **kwargs) -> Dict[str, Any]:
+        '''
+        Execute the solve event.
+
+        :param board: A 9-character board string (X, O, _).
+        :type board: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: A dict with board, minimax_result, and alphabeta_result.
+        :rtype: Dict[str, Any]
+        '''
+
+        # Validate board string length.
+        self.verify(
+            len(board) == 9,
+            'INVALID_INPUT',
+            f'Board must be exactly 9 characters, got {len(board)}',
+            board=board,
+        )
+
+        # Validate board string characters.
+        self.verify(
+            all(c in ('X', 'O', '_') for c in board),
+            'INVALID_INPUT',
+            f'Board must contain only X, O, or _ characters',
+            board=board,
+        )
+
+        # Parse the board string into a list of integers.
+        cells = BoardUtils.parse_board(board)
+
+        # Run plain minimax search.
+        mm_value, mm_nodes = Minimax.run(cells)
+
+        # Create a GameResultAggregate for the minimax result.
+        minimax_result = Aggregate.new(
+            GameResultAggregate,
+            value=mm_value,
+            nodes=mm_nodes,
+            algorithm='minimax',
+            cutoffs=[],
+        )
+
+        # Create a GameResultAggregate for the alpha-beta result.
+        # Initialize with placeholder values; will be updated after search.
+        ab_result = Aggregate.new(
+            GameResultAggregate,
+            value=0,
+            nodes=0,
+            algorithm='alphabeta',
+            cutoffs=[],
+            validate=False,
+        )
+
+        # Run alpha-beta search with the aggregate's record_cutoff as callback.
+        ab_value, ab_nodes = AlphaBeta.run(cells, on_cutoff=ab_result.record_cutoff)
+
+        # Update the alpha-beta aggregate with final values.
+        ab_result.set_attribute('value', ab_value)
+        ab_result.set_attribute('nodes', ab_nodes)
+
+        # Return results dict for downstream events.
+        return dict(
+            board=cells,
+            minimax_result=minimax_result,
+            alphabeta_result=ab_result,
+        )
+
+
+# ** event: print_results
+class PrintResults(DomainEvent):
+    '''
+    Domain event that formats and prints search results.
+    '''
+
+    # * method: execute
+    @DomainEvent.parameters_required(['results'])
+    def execute(self, results: Dict[str, Any], **kwargs) -> str:
+        '''
+        Format and print the solver results to stdout.
+
+        :param results: A dict containing board, minimax_result, and alphabeta_result.
+        :type results: Dict[str, Any]
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: Empty string to suppress CLI None output.
+        :rtype: str
+        '''
+
+        # Extract results components.
+        board = results['board']
+        minimax_result: GameResultAggregate = results['minimax_result']
+        ab_result: GameResultAggregate = results['alphabeta_result']
+
+        # Print the initial board.
+        print(BoardUtils.format_board(board))
+
+        # Print minimax results.
+        print(f'Game Result: {minimax_result.value}')
+        print(f'Moves considered without alpha-beta pruning: {minimax_result.nodes}')
+
+        # Print each alpha-beta cutoff (board + cutoff type).
+        for i, cutoff in enumerate(ab_result.cutoffs):
+            if i > 0:
+                print()
+            print(BoardUtils.format_board(cutoff.board))
+            print(cutoff.cutoff_type)
+
+        # Print alpha-beta summary stats.
+        print(f'Game Result: {ab_result.value}')
+        print(f'Moves considered with alpha-beta pruning: {ab_result.nodes}')
+        print(f'Alpha cuts: {ab_result.alpha_cuts}')
+        print(f'Beta cuts: {ab_result.beta_cuts}')
+
+        # Return empty string to suppress CLI 'None' output.
+        return ''

--- a/docs/guides/events/tictactoe.md
+++ b/docs/guides/events/tictactoe.md
@@ -1,0 +1,104 @@
+# Tic-Tac-Toe Events
+
+**Module:** `app/events/tictactoe.py`
+
+Two chained domain events that together implement the solver pipeline. `SolveTicTacToe` handles computation and `PrintResults` handles presentation — cleanly separated via Tiferet's `data_key` mechanism in `feature.yml`.
+
+## SolveTicTacToe
+
+Orchestrates both search algorithms and collects results.
+
+### Parameters
+
+- **`board`** (required) — A 9-character string using `X`, `O`, `_`.
+
+### Validation
+
+Uses `self.verify()` to enforce:
+- Board must be exactly 9 characters.
+- Board must contain only `X`, `O`, or `_`.
+
+Invalid input raises `INVALID_INPUT` (defined in `app/configs/error.yml`).
+
+### Execution Flow
+
+1. Parse the board string via `BoardUtils.parse_board()`.
+2. Run `Minimax.run()` → create a `GameResultAggregate` with the minimax results.
+3. Create a second `GameResultAggregate` for alpha-beta (with placeholder values).
+4. Run `AlphaBeta.run()`, passing `aggregate.record_cutoff` as the `on_cutoff` callback. The aggregate collects `Cutoff` domain objects during the search.
+5. Update the alpha-beta aggregate with final `value` and `nodes` via `set_attribute()`.
+6. Return a results dict:
+
+```python
+{
+    'board': List[int],                      # parsed board
+    'minimax_result': GameResultAggregate,   # minimax outcome
+    'alphabeta_result': GameResultAggregate, # alphabeta outcome with cutoffs
+}
+```
+
+The feature config stores this dict into request data via `data_key: results`.
+
+### Container Registration
+
+```yaml
+# app/configs/container.yml
+solve_tictactoe_evt:
+  module_path: app.events.tictactoe
+  class_name: SolveTicTacToe
+```
+
+## PrintResults
+
+Reads the results dict from request data and prints formatted output per homework spec.
+
+### Parameters
+
+- **`results`** (required) — The dict stored by `SolveTicTacToe` via `data_key`.
+
+### Output Format
+
+1. Initial board (3 rows)
+2. Minimax results: `Game Result: {value}` + `Moves considered without alpha-beta pruning: {nodes}`
+3. For each cutoff in the alphabeta result: board (3 rows) + cutoff type, separated by blank lines
+4. Alpha-beta summary: `Game Result: {value}` + `Moves considered with alpha-beta pruning: {nodes}` + `Alpha cuts: {n}` + `Beta cuts: {n}`
+
+### Container Registration
+
+```yaml
+# app/configs/container.yml
+print_results_evt:
+  module_path: app.events.tictactoe
+  class_name: PrintResults
+```
+
+## Feature Chain
+
+The two events are chained in `app/configs/feature.yml`:
+
+```yaml
+features:
+  tictactoe:
+    solve:
+      name: Solve Tic-Tac-Toe
+      commands:
+        - attribute_id: solve_tictactoe_evt
+          name: Solve the board with Minimax and Alpha-Beta
+          data_key: results
+        - attribute_id: print_results_evt
+          name: Print formatted results to stdout
+```
+
+The `data_key: results` on the first command stores its return value into `request.data['results']`. The second command receives it as the `results` parameter.
+
+## GameResultAggregate
+
+**Module:** `app/mappers/result.py`
+
+The mutable aggregate that bridges the domain and utility layers. Key members:
+
+- **`record_cutoff(board, cutoff_type)`** — Creates a `Cutoff` domain object and appends it to `self.cutoffs`. This method is passed as the `on_cutoff` callback into `AlphaBeta.run()`.
+- **`alpha_cuts`** (property) — Count of cutoffs where `cutoff_type == 'Alpha cut'`.
+- **`beta_cuts`** (property) — Count of cutoffs where `cutoff_type == 'Beta cut'`.
+
+This keeps the aggregate as the single point of mutation — the utility never modifies domain state directly.


### PR DESCRIPTION
## Summary

Add two chained domain events in `app/events/tictactoe.py`:

- **`SolveTicTacToe`** — Validates board input, runs Minimax and AlphaBeta, collects cutoffs via `GameResultAggregate.record_cutoff`, returns results dict stored via `data_key`.
- **`PrintResults`** — Reads results from request data, formats and prints output per homework spec. Returns `''` to suppress CLI `None`.

### Files
- `app/events/tictactoe.py` — both domain events
- `app/events/__init__.py` — package exports
- `docs/guides/events/tictactoe.md` — usage guide with feature chain docs

### Acceptance Criteria Verified
1. Correct output for `O_XOXX___` (board, minimax stats, cutoff blocks, alphabeta stats) ✓
2. Invalid board (`BAD`) raises `TiferetError` with `INVALID_INPUT` ✓
3. Terminal board → 1 node, 0 cutoffs ✓
4. `PrintResults` returns `''` ✓
5. Package exports work ✓
6. Guide exists ✓

Closes #6

Co-Authored-By: Oz <oz-agent@warp.dev>